### PR TITLE
Enable CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'csharp', 'javascript' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Autobuild
+      if: ${{ matrix.language == 'javascript' }}
+      uses: github/codeql-action/autobuild@v3
+
+    - name: Custom Build
+      if: ${{ matrix.language == 'csharp' }}
+      run: |
+        echo "Run, Build Application using script"
+        ./test/TestCSharpApplication/build_CodeQL.cmd
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/test/TestCSharpApplication/build_CodeQL.cmd
+++ b/test/TestCSharpApplication/build_CodeQL.cmd
@@ -1,0 +1,2 @@
+dotnet restore test/TestCSharpApplication/src/TestCSharpApplication/Service1/Service1.csproj -s https://api.nuget.org/v3/index.json
+dotnet build test/TestCSharpApplication/src/TestCSharpApplication/Service1/Service1.csproj -v normal


### PR DESCRIPTION
This PR enables CodeQL for code analysis as part of security sprint work.

- Add CodeQL workflow file
- Javascript analysis via default build
- C# analysis via custom build. This required making a new build.cmd file for CodeQL as the other was not compatible.