### PR TITLE
Treat Warnings as Errors and update .NET version

### DIFF
--- a/test/TestCSharpApplication/src/TestCSharpApplication/Service1/Service1.csproj
+++ b/test/TestCSharpApplication/src/TestCSharpApplication/Service1/Service1.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <Description>Stateless Service Application</Description>
     <Authors> </Authors>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0.3</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>Service1</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Service1</PackageId>


### PR DESCRIPTION
As part of security sprint work, builds should be run with TreatWarningsAsErrors enabled.

This PR sets the config, ran a test build and there was a security vulnerability in the target framework of 2.0. The nearest suggested framework without the vulnerability was 2.0.3, so updated the target framework as well to remove the vulnerability.